### PR TITLE
docs: standardize README following org template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,109 @@
-# SalesPitch [![Sparkline](https://stars.medv.io/Atypical-Consulting/SalesPitch.svg)](https://stars.medv.io/Atypical-Consulting/SalesPitch)
+# SalesPitch
 
-SalesPitch is a sales pitch generation application using OpenAI GPT-4. Create impactful sales pitches for your products in just a few simple steps.
+> **Generate tailored, professional sales pitches in seconds using AI — stop choosing between generic copy and hours of personalization.**
+
+<!-- Badges: Row 1 — Identity -->
+[![Atypical-Consulting - SalesPitch](https://img.shields.io/static/v1?label=Atypical-Consulting&message=SalesPitch&color=blue&logo=github)](https://github.com/Atypical-Consulting/SalesPitch)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET 9](https://img.shields.io/badge/.NET-9.0-purple?logo=dotnet)](https://dotnet.microsoft.com/)
+[![stars - SalesPitch](https://img.shields.io/github/stars/Atypical-Consulting/SalesPitch?style=social)](https://github.com/Atypical-Consulting/SalesPitch)
+[![forks - SalesPitch](https://img.shields.io/github/forks/Atypical-Consulting/SalesPitch?style=social)](https://github.com/Atypical-Consulting/SalesPitch)
+
+<!-- Badges: Row 2 — Activity -->
+[![GitHub tag](https://img.shields.io/github/tag/Atypical-Consulting/SalesPitch?include_prereleases=&sort=semver&color=blue)](https://github.com/Atypical-Consulting/SalesPitch/releases/)
+[![issues - SalesPitch](https://img.shields.io/github/issues/Atypical-Consulting/SalesPitch)](https://github.com/Atypical-Consulting/SalesPitch/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/Atypical-Consulting/SalesPitch)](https://github.com/Atypical-Consulting/SalesPitch/pulls)
+[![GitHub last commit](https://img.shields.io/github/last-commit/Atypical-Consulting/SalesPitch)](https://github.com/Atypical-Consulting/SalesPitch/commits/main)
+
+<!-- Badges: Row 3 — Quality -->
+[![Build](https://github.com/Atypical-Consulting/SalesPitch/actions/workflows/continuous.yml/badge.svg)](https://github.com/Atypical-Consulting/SalesPitch/actions/workflows/continuous.yml)
+
+---
 
 ![SalesPitch](./assets/salespitch.png)
 
-## Features
+## Table of Contents
 
-* Interacts with OpenAI GPT-4o to generate sales pitches
-* Supports multiple languages (French, English, German, and Spanish)
-* Includes various sales pitch frameworks
-    * AIDA (Attention, Interest, Desire, Action)
-    * PAS (Problem-Agitate-Solve)
-    * USP (Unique Selling Proposition)
-    * Features-Benefits
-    * Storytelling
-    * WIIFM (What’s In It For Me)
-    * Youtility
-    * FAB (Features, Advantages, Benefits)
-    * HHE (Headline, Hook, Empathy)
-    * SUSPENSE (Surprise, Uniqueness, Specifics, Promise, Excitement, Newness, Story)
-* User-friendly interface with Spectre.Console
-* Ability to use demo data
+- [The Problem](#the-problem)
+- [The Solution](#the-solution)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+- [Architecture](#architecture)
+- [Project Structure](#project-structure)
+- [Roadmap](#roadmap)
+- [Stats](#stats)
+- [Contributing](#contributing)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
 
-## Stats
+## The Problem
 
-![Alt](https://repobeats.axiom.co/api/embed/9e8cea0532101e0c02a5034825d6be9f1b40f732.svg "Repobeats analytics image")
+Writing compelling, tailored sales pitches for every prospect is time-consuming. Sales teams either write generic pitches that fail to resonate, or spend hours personalizing each one. Existing tools lack support for proven sales frameworks and multi-language output, forcing teams to manually adapt their messaging for different audiences and markets.
 
-## Installation
+## The Solution
 
-Ensure that you have .NET 9.0 or a later version installed on your machine.
-
-Clone this repository and navigate to the source folder:
+**SalesPitch** uses OpenAI GPT-4 to generate tailored, professional sales pitches from minimal input via an interactive CLI. Choose from 10 proven sales frameworks, pick your target language, describe your product, and get a polished pitch in seconds.
 
 ```sh
-git clone https://github.com/user/SalesPitch.git
-cd SalesPitch
+dotnet run --configuration Release --project src/SalesPitch
+
+# The interactive CLI will guide you through:
+# 1. Select a language (French, English, German, Spanish)
+# 2. Choose a sales framework (AIDA, PAS, USP, etc.)
+# 3. Describe your product
+# 4. Receive a tailored sales pitch powered by GPT-4
 ```
 
-Install the dependencies and build the project:
+## Features
 
-```sh
+- [x] AI-powered pitch generation using OpenAI GPT-4o
+- [x] 10 proven sales pitch frameworks (AIDA, PAS, USP, Features-Benefits, Storytelling, WIIFM, Youtility, FAB, HHE, SUSPENSE)
+- [x] Multi-language support (French, English, German, Spanish)
+- [x] Interactive CLI powered by Spectre.Console
+- [x] Demo data mode for quick evaluation
+- [x] User secrets support for secure API key storage
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | .NET 9.0 |
+| AI | OpenAI GPT-4 via [Betalgo.Ranul.OpenAI](https://github.com/betalgo/openai) 9.x |
+| CLI | [Spectre.Console](https://spectreconsole.net/) 0.49 |
+| DI | [Scrutor](https://github.com/khellang/Scrutor) 5.x |
+| Build | [Nuke](https://nuke.build/) |
+
+## Getting Started
+
+### Prerequisites
+
+- [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later
+- An [OpenAI API key](https://platform.openai.com/signup/)
+
+### Installation
+
+**From Source**
+
+```bash
+git clone https://github.com/Atypical-Consulting/SalesPitch.git
+cd SalesPitch
 dotnet restore
 dotnet build --configuration Release
 ```
 
-## Configuration
+### Configuration
 
-1. Obtain an API key from OpenAI ([https://beta.openai.com/signup/](https://beta.openai.com/signup/))
-2. Create an `appsettings.json` file at the root of the project with the API key:
+Set your OpenAI API key using .NET user secrets (recommended):
+
+```bash
+cd src/SalesPitch
+dotnet user-secrets set "OpenAIServiceOptions:ApiKey" "<your_openai_api_key>"
+dotnet user-secrets set "OpenAIServiceOptions:Organization" "<your_organization_id>"
+```
+
+Or create an `appsettings.json` file in the project root:
 
 ```json
 {
@@ -60,26 +116,117 @@ dotnet build --configuration Release
 
 ## Usage
 
-Run the application using the following command at the root of the project:
+Run the application from the repository root:
 
 ```sh
 dotnet run --configuration Release --project src/SalesPitch
 ```
 
-The application will guide you through several steps to generate a sales pitch for your product. You can also use the demo data to see how the application works.
+The interactive CLI will guide you through several steps to generate a sales pitch for your product. You can also use the demo data to see how the application works.
 
-## Contribution
+## Architecture
 
-If you wish to contribute to this project, please submit a pull request or open an issue in the GitHub repository.
+```
+┌─────────────────────────────────────────────────┐
+│                   CLI Input                      │
+│          (Language, Framework, Product)           │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│              Spectre.Console CLI                 │
+│     (Interactive prompts, rich formatting)       │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│            Language Service Layer                │
+│   (FR / EN / DE / ES prompt localization)        │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│              OpenAI GPT-4 API                    │
+│         (Betalgo.Ranul.OpenAI SDK)               │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│             Formatted Output                     │
+│       (Sales pitch in chosen language)           │
+└─────────────────────────────────────────────────┘
+```
+
+### Project Structure
+
+```
+SalesPitch/
+├── src/
+│   └── SalesPitch/
+│       ├── Commands/           # CLI command definitions and settings
+│       ├── Extensions/         # Response extension methods
+│       ├── Infrastructure/     # DI type resolver and registrar
+│       ├── Services/
+│       │   └── Language/       # Language-specific prompt services
+│       ├── TypeConverters/     # Custom type converters
+│       └── Program.cs          # Application entry point
+├── build/                      # Nuke build automation
+├── assets/                     # Screenshots and images
+├── SalesPitch.sln              # Solution file
+└── README.md
+```
+
+## Roadmap
+
+- [ ] Add more languages (Italian, Portuguese, Japanese, Chinese)
+- [ ] Template customization — let users define custom pitch structures
+- [ ] Batch generation — generate pitches for multiple products at once
+- [ ] Export to PDF/Markdown/HTML
+- [ ] Tone control — formal, casual, persuasive, technical
+- [ ] Cost estimation — show token usage and API cost per generation
+
+> Want to contribute? Pick any roadmap item and open a PR!
+
+## Stats
+
+![Alt](https://repobeats.axiom.co/api/embed/9e8cea0532101e0c02a5034825d6be9f1b40f732.svg "Repobeats analytics image")
+
+## Contributing
+
+Contributions are welcome! Here's how to get started:
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit using [conventional commits](https://www.conventionalcommits.org/) (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+### Conventional Commits
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+| Prefix | Purpose |
+|--------|---------|
+| `feat:` | A new feature |
+| `fix:` | A bug fix |
+| `docs:` | Documentation changes |
+| `refactor:` | Code refactoring (no feature or fix) |
+| `test:` | Adding or updating tests |
+| `chore:` | Maintenance tasks |
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.
+[MIT](LICENSE) © 2023 [Atypical Consulting](https://atypical.garry-ai.cloud)
 
 ## Acknowledgments
 
-This application was inspired by the following article: [Write A Great Chat GPT Sales Pitch in 5 Steps](https://txtly.ai/write-a-chat-gpt-sales-pitch/)
+- Inspired by [Write A Great Chat GPT Sales Pitch in 5 Steps](https://txtly.ai/write-a-chat-gpt-sales-pitch/)
+- [OpenAI](https://openai.com/) — GPT-4 language model
+- [Spectre.Console](https://spectreconsole.net/) — Beautiful CLI framework for .NET
+- [Betalgo.OpenAI](https://github.com/betalgo/openai) — .NET SDK for OpenAI
 
-* [OpenAI](https://openai.com/)
-* [Spectre.Console](https://spectreconsole.net/)
-* [Betalgo.OpenAI](https://github.com/betalgo/openai)
+---
+
+Built with care by [Atypical Consulting](https://atypical.garry-ai.cloud) — opinionated, production-grade open source.
+
+[![Contributors](https://contrib.rocks/image?repo=Atypical-Consulting/SalesPitch)](https://github.com/Atypical-Consulting/SalesPitch/graphs/contributors)


### PR DESCRIPTION
## Summary

- Restructured README to follow the Atypical Consulting standardized template
- Added full badge wall (identity, activity, quality rows) with correct repo metadata
- Added "The Problem" and "The Solution" sections explaining the project's value proposition
- Added Table of Contents linking all sections
- Added Tech Stack table (.NET 9, OpenAI GPT-4, Spectre.Console, Scrutor, Nuke)
- Added Architecture diagram showing the CLI-to-API data flow
- Added accurate Project Structure tree from the actual repo layout
- Added Roadmap with planned features (more languages, templates, batch generation, export, tone control)
- Expanded Contributing section with conventional commits guide
- Added branding footer and contributors image
- Preserved existing content: features list, stats/RepoBeats, installation, configuration, usage, license, acknowledgments