### PR TITLE
fix: remove broken Nuke.Common.IO imports after v10 upgrade

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,8 +12,6 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
 using static Nuke.Common.EnvironmentInfo;
-using static Nuke.Common.IO.FileSystemTasks;
-using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName


### PR DESCRIPTION
## Summary
- Removes `using static Nuke.Common.IO.FileSystemTasks;` and `using static Nuke.Common.IO.PathConstruction;` from `build/Build.cs`
- Both types were removed in Nuke.Common v10 (merged via Renovate PR #19)
- The code already uses the new Nuke v10 extension method API (`AbsolutePath.GlobDirectories()`, `AbsolutePath.CreateOrCleanDirectory()`, `/` operator) so these imports were unused

## Root Cause
PR #19 upgraded `Nuke.Common` to v10, which removed `FileSystemTasks` and `PathConstruction` from `Nuke.Common.IO`. The build script referenced these in `using static` imports, causing `error CS0234` on CI.

## Test plan
- [ ] CI (`continuous` workflow) passes after merge