### PR TITLE
fix: update ExecuteAsync signature for Spectre.Console breaking change

### DIFF
--- a/src/SalesPitch/Commands/SalesPitchCommand.cs
+++ b/src/SalesPitch/Commands/SalesPitchCommand.cs
@@ -42,7 +42,8 @@ public sealed class SalesPitchCommand
     /// <returns>The exit code</returns>
     public override async Task<int> ExecuteAsync(
         CommandContext context,
-        SalesPitchSettings settings)
+        SalesPitchSettings settings,
+        CancellationToken cancellationToken)
     {
         // Display a header and a rule
         AnsiConsole.Write(


### PR DESCRIPTION
## Summary
- Updates `SalesPitchCommand.ExecuteAsync` to include the `CancellationToken` parameter required by the latest Spectre.Console `AsyncCommand<T>` base class
- This breaking change was introduced by the Spectre.Console monorepo update merged in PR #16

## Root Cause
Spectre.Console changed the `AsyncCommand<T>.ExecuteAsync` signature to require a `CancellationToken` parameter. The existing override without it causes:
- `CS0115`: no suitable method found to override
- `CS0534`: does not implement inherited abstract member

## Test plan
- [ ] CI (`continuous` workflow) passes after merge