### PR TITLE
ci: restrict triggers to main branch and add concurrency

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -16,7 +16,15 @@
 
 name: continuous
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu-latest:
@@ -32,6 +40,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- Change workflow trigger from all pushes to push/PR on main only
- Add concurrency group to cancel redundant workflow runs
- Add .NET 10.0.x SDK alongside existing 8.0.x and 9.0.x

## Test plan
- [ ] Verify workflow no longer triggers on feature branch pushes
- [ ] Verify workflow triggers on push to main and PRs to main
- [ ] Verify build succeeds with added .NET 10.0.x SDK